### PR TITLE
adds cors middleware allowing all domains

### DIFF
--- a/components/home/featuredDestinations/featuredDestinations.components.tsx
+++ b/components/home/featuredDestinations/featuredDestinations.components.tsx
@@ -1,9 +1,11 @@
 import { useQuery } from "@tanstack/react-query"
+import axios from "axios";
 import { request } from "../../../helpers/axios-util";
 import Card from "./cardDetail";
 
 const fetchFeaturedDestinations = () => {
-  return request({url: '/db'})
+  return axios.get('https://hotel-booking-app-tau.vercel.app/api/db/db')
+  // return request({url: '/db'})
 }
 
 const placeholderAvatar = '/img/destinations/avatar.png'
@@ -13,7 +15,8 @@ export const FeaturedDestinations = () => {
   const {data, isInitialLoading} = useQuery(['featured-dest'], fetchFeaturedDestinations)
   if(isInitialLoading) return <h2>Loading...</h2>
 
-  console.log(data?.data["featured-destinations"])
+  console.log("data", data?.data)
+  // console.log(data?.data["featured-destinations"])
 
   return (
     <>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
       "dependencies": {
         "@tanstack/react-query": "^4.12.0",
         "@types/bcryptjs": "^2.4.2",
+        "@types/cors": "^2.8.12",
         "axios": "^1.1.3",
         "bcryptjs": "^2.4.3",
+        "cors": "^2.8.5",
         "formik": "^2.2.9",
         "json-server": "^0.17.0",
         "next": "12.3.0",
@@ -484,6 +486,11 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.2.tgz",
       "integrity": "sha512-LiMQ6EOPob/4yUL66SZzu6Yh77cbzJFYll+ZfaPiPPFswtIlA/Fs1MzdKYA7JApHU49zQTbJGX3PDmCpIdDBRQ=="
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
+      "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -6332,6 +6339,11 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.2.tgz",
       "integrity": "sha512-LiMQ6EOPob/4yUL66SZzu6Yh77cbzJFYll+ZfaPiPPFswtIlA/Fs1MzdKYA7JApHU49zQTbJGX3PDmCpIdDBRQ=="
+    },
+    "@types/cors": {
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
+      "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw=="
     },
     "@types/json5": {
       "version": "0.0.29",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
   "dependencies": {
     "@tanstack/react-query": "^4.12.0",
     "@types/bcryptjs": "^2.4.2",
+    "@types/cors": "^2.8.12",
     "axios": "^1.1.3",
     "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
     "formik": "^2.2.9",
     "json-server": "^0.17.0",
     "next": "12.3.0",

--- a/pages/api/db/db.ts
+++ b/pages/api/db/db.ts
@@ -1,3 +1,5 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+import Cors from 'cors'
 const rawData = `{
   "best-place": [
     {
@@ -310,7 +312,7 @@ const rawData = `{
           "location": "Australia",
           "img": "",
           "rating": 5,
-          "review": "As first time Paris-explorers, Bryan’s accommodation was perfect for our family of four (including two teens). Close to the glories of the Haussmann district and Gallery Lafayette,"
+          "review": "As first time Paris-explorers, Bryan's accommodation was perfect for our family of four (including two teens). Close to the glories of the Haussmann district and Gallery Lafayette,"
         },
         {
           "name": "Helen",
@@ -682,7 +684,7 @@ const rawData = `{
           "location": "Australia",
           "img": "",
           "rating": 5,
-          "review": "As first time Paris-explorers, Bryan’s accommodation was perfect for our family of four (including two teens). Close to the glories of the Haussmann district and Gallery Lafayette,"
+          "review": "As first time Paris-explorers, Bryan's accommodation was perfect for our family of four (including two teens). Close to the glories of the Haussmann district and Gallery Lafayette,"
         },
         {
           "name": "Helen",
@@ -721,10 +723,33 @@ const rawData = `{
   }
 }
 `
+// Initialize cors middleware
+const cors = Cors({
+  methods: ['POST', 'GET', 'HEAD'],
+})
+
+function runMiddleWare(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  fn: Function
+) {
+  return new Promise((resolve, reject) => {
+    fn(req, res, (result: any) => {
+      if(result instanceof Error) {
+        return reject(result)
+      }
+
+      return resolve(result)
+    })
+  })
+}
+
 let data = JSON.parse(rawData)
 
-export default function handler(req: any, res: any) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  await runMiddleWare(req, res, cors)
+  
   if(req.method === 'GET') {
-    res.status(200).json(data)
+    res.json(data)
   }
 }

--- a/pages/fetch-test/index.tsx
+++ b/pages/fetch-test/index.tsx
@@ -20,7 +20,7 @@ const FetchTest: NextPage = () => {
 
   const {data: places, isInitialLoading} = useQuery(['travel-data'], fetchTravelData) // use alias for data destructure
   
-  console.log("data", places?.data["best-place"])
+  console.log("data", places?.data)
 
   if(isInitialLoading) return <h2>Loading...</h2>
 


### PR DESCRIPTION
Potential solution to allow us to make get requests to the vercel api endpoint for development purposes. Shouldn't affect the functionality of the deployed version of the app, only on the development side. Can be easily removed if unusable. 